### PR TITLE
fix hybridLogin typo

### DIFF
--- a/packages/service-provider-torus/src/TorusServiceProvider.ts
+++ b/packages/service-provider-torus/src/TorusServiceProvider.ts
@@ -41,7 +41,7 @@ class TorusServiceProvider extends ServiceProviderBase {
     return obj;
   }
 
-  async triggerHybirdLogin(params: HybridAggregateLoginParams): Promise<TorusHybridAggregateLoginResponse> {
+  async triggerHybridAggregateLogin(params: HybridAggregateLoginParams): Promise<TorusHybridAggregateLoginResponse> {
     const obj = await this.directWeb.triggerHybridAggregateLogin(params);
     const aggregateLoginKey = obj.aggregateLogins[0].privateKey;
     this.postboxKey = new BN(aggregateLoginKey, "hex");

--- a/packages/service-provider-torus/types/src/TorusServiceProvider.d.ts
+++ b/packages/service-provider-torus/types/src/TorusServiceProvider.d.ts
@@ -10,7 +10,7 @@ declare class TorusServiceProvider extends ServiceProviderBase {
     init(params: InitParams): Promise<void>;
     triggerLogin(params: SubVerifierDetails): Promise<TorusLoginResponse>;
     triggerAggregateLogin(params: AggregateLoginParams): Promise<TorusAggregateLoginResponse>;
-    triggerHybirdLogin(params: HybridAggregateLoginParams): Promise<TorusHybridAggregateLoginResponse>;
+    triggerHybridAggregateLogin(params: HybridAggregateLoginParams): Promise<TorusHybridAggregateLoginResponse>;
     toJSON(): StringifiedType;
     static fromJSON(value: StringifiedType): TorusServiceProvider;
 }


### PR DESCRIPTION
The hybridLogin function in the service-provider-torus package contained a typo.
I figured it should be triggerHybridAggregateLogin so it matches the direct web sdk.