### PR TITLE
Allow not sync on setTkeyStoreItem

### DIFF
--- a/packages/common-types/src/baseTypes/aggregateTypes.ts
+++ b/packages/common-types/src/baseTypes/aggregateTypes.ts
@@ -242,7 +242,7 @@ export interface ITKeyApi {
   getTKeyStoreItem(moduleName: string, id: string): Promise<TkeyStoreItemType>;
   getTKeyStore(moduleName: string): Promise<TkeyStoreItemType[]>;
   deleteTKeyStoreItem(moduleName: string, id: string): Promise<void>;
-  setTKeyStoreItem(moduleName: string, data: TkeyStoreItemType): Promise<void>;
+  setTKeyStoreItem(moduleName: string, data: TkeyStoreItemType, sync?: boolean): Promise<void>;
 }
 
 // eslint-disable-next-line no-use-before-define

--- a/packages/common-types/src/baseTypes/aggregateTypes.ts
+++ b/packages/common-types/src/baseTypes/aggregateTypes.ts
@@ -242,7 +242,7 @@ export interface ITKeyApi {
   getTKeyStoreItem(moduleName: string, id: string): Promise<TkeyStoreItemType>;
   getTKeyStore(moduleName: string): Promise<TkeyStoreItemType[]>;
   deleteTKeyStoreItem(moduleName: string, id: string): Promise<void>;
-  setTKeyStoreItem(moduleName: string, data: TkeyStoreItemType, sync?: boolean): Promise<void>;
+  setTKeyStoreItem(moduleName: string, data: TkeyStoreItemType, updateMetadata?: boolean): Promise<void>;
 }
 
 // eslint-disable-next-line no-use-before-define

--- a/packages/common-types/types/src/baseTypes/aggregateTypes.d.ts
+++ b/packages/common-types/types/src/baseTypes/aggregateTypes.d.ts
@@ -121,10 +121,13 @@ export interface ShareRequestArgs {
 }
 export declare type TkeyStoreItemType = {
     id: string;
-    type: string;
 };
 export declare type ISeedPhraseStore = TkeyStoreItemType & {
     seedPhrase: string;
+    type: string;
+};
+export declare type ISQAnswerStore = TkeyStoreItemType & {
+    answer: string;
 };
 export declare type ISeedPhraseStoreWithKeys = ISeedPhraseStore & {
     keys: BN[];
@@ -134,6 +137,7 @@ export declare type MetamaskSeedPhraseStore = ISeedPhraseStore & {
 };
 export declare type IPrivateKeyStore = TkeyStoreItemType & {
     privateKey: BN;
+    type: string;
 };
 export declare type SECP256k1NStore = IPrivateKeyStore;
 export interface ISeedPhraseFormat {
@@ -175,7 +179,7 @@ export interface ITKeyApi {
     getTKeyStoreItem(moduleName: string, id: string): Promise<TkeyStoreItemType>;
     getTKeyStore(moduleName: string): Promise<TkeyStoreItemType[]>;
     deleteTKeyStoreItem(moduleName: string, id: string): Promise<void>;
-    setTKeyStoreItem(moduleName: string, data: TkeyStoreItemType): Promise<void>;
+    setTKeyStoreItem(moduleName: string, data: TkeyStoreItemType, sync?: boolean): Promise<void>;
 }
 export interface ITKey extends ITKeyApi, ISerializable {
     modules: ModuleMap;

--- a/packages/common-types/types/src/baseTypes/aggregateTypes.d.ts
+++ b/packages/common-types/types/src/baseTypes/aggregateTypes.d.ts
@@ -179,7 +179,7 @@ export interface ITKeyApi {
     getTKeyStoreItem(moduleName: string, id: string): Promise<TkeyStoreItemType>;
     getTKeyStore(moduleName: string): Promise<TkeyStoreItemType[]>;
     deleteTKeyStoreItem(moduleName: string, id: string): Promise<void>;
-    setTKeyStoreItem(moduleName: string, data: TkeyStoreItemType, sync?: boolean): Promise<void>;
+    setTKeyStoreItem(moduleName: string, data: TkeyStoreItemType, updateMetadata?: boolean): Promise<void>;
 }
 export interface ITKey extends ITKeyApi, ISerializable {
     modules: ModuleMap;

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -793,9 +793,7 @@ class ThresholdKey implements ITKey {
 
     // update metadataStore
     this.metadata.setTkeyStoreDomain(moduleName, rawTkeyStoreItems);
-
-    const shouldSync = updateMetadata === null || updateMetadata === undefined ? true : updateMetadata;
-    if (shouldSync) await this.syncShareMetadata();
+    if (updateMetadata) await this.syncShareMetadata();
   }
 
   async deleteTKeyStoreItem(moduleName: string, id: string): Promise<void> {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -775,7 +775,7 @@ class ThresholdKey implements ITKey {
     return decrypt(toPrivKeyECC(this.privKey), encryptedMessage);
   }
 
-  async setTKeyStoreItem(moduleName: string, data: TkeyStoreItemType): Promise<void> {
+  async setTKeyStoreItem(moduleName: string, data: TkeyStoreItemType, sync?: boolean): Promise<void> {
     const rawTkeyStoreItems: EncryptedMessage[] = (this.metadata.getTkeyStoreDomain(moduleName) as EncryptedMessage[]) || [];
     const decryptedItems = await Promise.all(
       rawTkeyStoreItems.map(async (x) => {
@@ -793,7 +793,9 @@ class ThresholdKey implements ITKey {
 
     // update metadataStore
     this.metadata.setTkeyStoreDomain(moduleName, rawTkeyStoreItems);
-    await this.syncShareMetadata();
+
+    const shouldSync = sync == null ? true : sync;
+    if (shouldSync) await this.syncShareMetadata();
   }
 
   async deleteTKeyStoreItem(moduleName: string, id: string): Promise<void> {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -775,7 +775,7 @@ class ThresholdKey implements ITKey {
     return decrypt(toPrivKeyECC(this.privKey), encryptedMessage);
   }
 
-  async setTKeyStoreItem(moduleName: string, data: TkeyStoreItemType, sync?: boolean): Promise<void> {
+  async setTKeyStoreItem(moduleName: string, data: TkeyStoreItemType, updateMetadata?: boolean): Promise<void> {
     const rawTkeyStoreItems: EncryptedMessage[] = (this.metadata.getTkeyStoreDomain(moduleName) as EncryptedMessage[]) || [];
     const decryptedItems = await Promise.all(
       rawTkeyStoreItems.map(async (x) => {
@@ -794,7 +794,7 @@ class ThresholdKey implements ITKey {
     // update metadataStore
     this.metadata.setTkeyStoreDomain(moduleName, rawTkeyStoreItems);
 
-    const shouldSync = sync === null || sync === undefined ? true : sync;
+    const shouldSync = updateMetadata === null || updateMetadata === undefined ? true : updateMetadata;
     if (shouldSync) await this.syncShareMetadata();
   }
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -794,7 +794,7 @@ class ThresholdKey implements ITKey {
     // update metadataStore
     this.metadata.setTkeyStoreDomain(moduleName, rawTkeyStoreItems);
 
-    const shouldSync = sync == null ? true : sync;
+    const shouldSync = sync === null || sync === undefined ? true : sync;
     if (shouldSync) await this.syncShareMetadata();
   }
 

--- a/packages/core/types/src/core.d.ts
+++ b/packages/core/types/src/core.d.ts
@@ -74,7 +74,7 @@ declare class ThresholdKey implements ITKey {
     deleteShareDescription(shareIndex: string, description: string, updateMetadata?: boolean): Promise<void>;
     encrypt(data: Buffer): Promise<EncryptedMessage>;
     decrypt(encryptedMessage: EncryptedMessage): Promise<Buffer>;
-    setTKeyStoreItem(moduleName: string, data: TkeyStoreItemType, sync?: boolean): Promise<void>;
+    setTKeyStoreItem(moduleName: string, data: TkeyStoreItemType, updateMetadata?: boolean): Promise<void>;
     deleteTKeyStoreItem(moduleName: string, id: string): Promise<void>;
     getTKeyStore(moduleName: string): Promise<TkeyStoreItemType[]>;
     getTKeyStoreItem(moduleName: string, id: string): Promise<TkeyStoreItemType>;

--- a/packages/core/types/src/core.d.ts
+++ b/packages/core/types/src/core.d.ts
@@ -74,7 +74,7 @@ declare class ThresholdKey implements ITKey {
     deleteShareDescription(shareIndex: string, description: string, updateMetadata?: boolean): Promise<void>;
     encrypt(data: Buffer): Promise<EncryptedMessage>;
     decrypt(encryptedMessage: EncryptedMessage): Promise<Buffer>;
-    setTKeyStoreItem(moduleName: string, data: TkeyStoreItemType): Promise<void>;
+    setTKeyStoreItem(moduleName: string, data: TkeyStoreItemType, sync?: boolean): Promise<void>;
     deleteTKeyStoreItem(moduleName: string, id: string): Promise<void>;
     getTKeyStore(moduleName: string): Promise<TkeyStoreItemType[]>;
     getTKeyStoreItem(moduleName: string, id: string): Promise<TkeyStoreItemType>;

--- a/packages/private-keys/src/PrivateKeys.ts
+++ b/packages/private-keys/src/PrivateKeys.ts
@@ -34,7 +34,7 @@ class PrivateKeyModule implements IModule {
       throw PrivateKeysError.invalidPrivateKey(`${privateKey}`);
     }
     const privateKeyStore = format.createPrivateKeyStore(privateKey);
-    return this.tbSDK.setTKeyStoreItem(this.moduleName, privateKeyStore);
+    return this.tbSDK.setTKeyStoreItem(this.moduleName, privateKeyStore, true);
   }
 
   async getPrivateKeys(): Promise<IPrivateKeyStore[]> {

--- a/packages/security-questions/src/SecurityQuestionsModule.ts
+++ b/packages/security-questions/src/SecurityQuestionsModule.ts
@@ -69,6 +69,7 @@ class SecurityQuestionsModule implements IModule {
     );
     // set on tkey store
     await this.saveAnswerOnTkeyStore(answerString);
+    await this.tbSDK.syncShareMetadata();
     return newSharesDetails;
   }
 
@@ -121,7 +122,7 @@ class SecurityQuestionsModule implements IModule {
     });
     metadata.setGeneralStoreDomain(this.moduleName, newSqStore);
     await this.saveAnswerOnTkeyStore(newAnswerString);
-    // await this.tbSDK.syncShareMetadata(); READ TODO1
+    await this.tbSDK.syncShareMetadata();
   }
 
   static refreshSecurityQuestionsMiddleware(generalStore: unknown, oldShareStores: ShareStoreMap, newShareStores: ShareStoreMap): unknown {
@@ -143,17 +144,13 @@ class SecurityQuestionsModule implements IModule {
   }
 
   async saveAnswerOnTkeyStore(answerString: string): Promise<void> {
-    //  TODO: TODO1 edit setTKeyStoreItem to not sync all the time.
-    if (this.saveAnswers) {
-      const answerStore: ISQAnswerStore = {
-        answer: answerString,
-        id: TKEYSTORE_ID,
-      };
-      await this.tbSDK.setTKeyStoreItem(this.moduleName, answerStore);
-    } else {
-      // TODO: TODO1 REMOVE THIS
-      await this.tbSDK.syncShareMetadata();
-    }
+    if (!this.saveAnswers) return;
+
+    const answerStore: ISQAnswerStore = {
+      answer: answerString,
+      id: TKEYSTORE_ID,
+    };
+    await this.tbSDK.setTKeyStoreItem(this.moduleName, answerStore, false);
   }
 
   async getAnswer(): Promise<string> {

--- a/packages/security-questions/types/src/SecurityQuestionsModule.d.ts
+++ b/packages/security-questions/types/src/SecurityQuestionsModule.d.ts
@@ -3,7 +3,8 @@ export declare const SECURITY_QUESTIONS_MODULE_NAME = "securityQuestions";
 declare class SecurityQuestionsModule implements IModule {
     moduleName: string;
     tbSDK: ITKeyApi;
-    constructor();
+    saveAnswers: boolean;
+    constructor(saveAnswers?: boolean);
     setModuleReferences(tbSDK: ITKeyApi): void;
     initialize(): Promise<void>;
     generateNewShareWithSecurityQuestions(answerString: string, questions: string): Promise<GenerateNewShareResult>;
@@ -11,5 +12,7 @@ declare class SecurityQuestionsModule implements IModule {
     inputShareFromSecurityQuestions(answerString: string): Promise<void>;
     changeSecurityQuestionAndAnswer(newAnswerString: string, newQuestions: string): Promise<void>;
     static refreshSecurityQuestionsMiddleware(generalStore: unknown, oldShareStores: ShareStoreMap, newShareStores: ShareStoreMap): unknown;
+    saveAnswerOnTkeyStore(answerString: string): Promise<void>;
+    getAnswer(): Promise<string>;
 }
 export default SecurityQuestionsModule;

--- a/packages/security-questions/types/src/errors.d.ts
+++ b/packages/security-questions/types/src/errors.d.ts
@@ -6,5 +6,6 @@ declare class SecurityQuestionsError extends TkeyError {
     static unavailable(extraMessage?: string): ITkeyError;
     static unableToReplace(extraMessage?: string): ITkeyError;
     static incorrectAnswer(extraMessage?: string): ITkeyError;
+    static noPasswordSaved(extraMessage?: string): ITkeyError;
 }
 export default SecurityQuestionsError;

--- a/packages/seed-phrase/src/SeedPhrase.ts
+++ b/packages/seed-phrase/src/SeedPhrase.ts
@@ -34,7 +34,7 @@ class SeedPhraseModule implements IModule {
       throw SeedPhraseError.invalid(`${seedPhraseType}`);
     }
     const seedPhraseStore = await format.createSeedPhraseStore(seedPhrase);
-    return this.tbSDK.setTKeyStoreItem(this.moduleName, seedPhraseStore);
+    return this.tbSDK.setTKeyStoreItem(this.moduleName, seedPhraseStore, true);
   }
 
   async setSeedPhraseStoreItem(partialStore: ISeedPhraseStore): Promise<void> {
@@ -42,7 +42,7 @@ class SeedPhraseModule implements IModule {
     const originalItem: ISeedPhraseStore = { id: seedPhraseItem.id, type: seedPhraseItem.type, seedPhrase: seedPhraseItem.seedPhrase };
     // Disallow editing critical fields
     const finalItem = { ...partialStore, ...originalItem };
-    return this.tbSDK.setTKeyStoreItem(this.moduleName, finalItem);
+    return this.tbSDK.setTKeyStoreItem(this.moduleName, finalItem, true);
   }
 
   async getSeedPhrases(): Promise<ISeedPhraseStore[]> {


### PR DESCRIPTION
Add option `sync` to `setTkeyStoreItem` to allow the caller to decide whether to sync. It syncs by default.
Update SecurityQuestion module to use this API for faster processing.
