### PR TITLE
Replace window with globalThis to work in non-window context

### DIFF
--- a/packages/web-storage/src/FileStorageHelpers.ts
+++ b/packages/web-storage/src/FileStorageHelpers.ts
@@ -1,11 +1,12 @@
 import { ShareStore } from "@tkey/common-types";
 
 import WebStorageError from "./errors";
+import { getWindow } from "./utils";
 
 // Web Specific declarations
 const requestedBytes = 1024 * 1024 * 10; // 10MB
 
-const win = globalThis as any;
+const win = getWindow();
 win.requestFileSystem = win.requestFileSystem || win.webkitRequestFileSystem;
 
 declare global {

--- a/packages/web-storage/src/FileStorageHelpers.ts
+++ b/packages/web-storage/src/FileStorageHelpers.ts
@@ -4,7 +4,10 @@ import WebStorageError from "./errors";
 
 // Web Specific declarations
 const requestedBytes = 1024 * 1024 * 10; // 10MB
-window.requestFileSystem = window.requestFileSystem || window.webkitRequestFileSystem;
+
+const win = globalThis as any;
+win.requestFileSystem = win.requestFileSystem || win.webkitRequestFileSystem;
+
 declare global {
   interface Navigator {
     webkitPersistentStorage: {
@@ -29,7 +32,7 @@ async function requestQuota(): Promise<number> {
 }
 async function browserRequestFileSystem(grantedBytes: number): Promise<FileSystem> {
   return new Promise((resolve, reject) => {
-    window.requestFileSystem(window.PERSISTENT, grantedBytes, resolve, reject);
+    win.requestFileSystem(win.PERSISTENT, grantedBytes, resolve, reject);
   });
 }
 async function getFile(fs: FileSystem, path: string, create: boolean): Promise<FileEntry> {
@@ -44,7 +47,7 @@ async function readFile(fileEntry: FileEntry): Promise<File> {
 }
 
 export const getShareFromFileStorage = async (key: string): Promise<ShareStore> => {
-  if (window.requestFileSystem) {
+  if (win.requestFileSystem) {
     const fs = await browserRequestFileSystem(requestedBytes);
 
     const fileEntry = await getFile(fs, key, false);
@@ -62,7 +65,7 @@ export const storeShareOnFileStorage = async (share: ShareStore, key: string): P
   // if we're on chrome (thus window.requestFileSystem exists) we use it
   const fileName = `${key}.json`;
   const fileStr = JSON.stringify(share);
-  if (window.requestFileSystem) {
+  if (win.requestFileSystem) {
     const grantedBytes = await requestQuota();
     const fs = await browserRequestFileSystem(grantedBytes);
     const fileEntry = await getFile(fs, key, true);

--- a/packages/web-storage/src/LocalStorageHelpers.ts
+++ b/packages/web-storage/src/LocalStorageHelpers.ts
@@ -1,11 +1,14 @@
 import { ShareStore } from "@tkey/common-types";
 
 import WebStorageError from "./errors";
+import { getWindow } from "./utils";
+
+const win = getWindow();
 
 function storageAvailable(type: string): boolean {
   let storage: Storage;
   try {
-    storage = globalThis[type];
+    storage = win[type];
     const x = "__storage_test__";
     storage.setItem(x, x);
     storage.removeItem(x);
@@ -34,14 +37,14 @@ export const storeShareOnLocalStorage = async (share: ShareStore, key: string): 
   if (!storageAvailable("localStorage")) {
     throw WebStorageError.localStorageUnavailable();
   }
-  globalThis.localStorage.setItem(key, fileStr);
+  win.localStorage.setItem(key, fileStr);
 };
 
 export const getShareFromLocalStorage = async (key: string): Promise<ShareStore> => {
   if (!storageAvailable("localStorage")) {
     throw WebStorageError.localStorageUnavailable();
   }
-  const foundFile = globalThis.localStorage.getItem(key);
+  const foundFile = win.localStorage.getItem(key);
   if (!foundFile) throw WebStorageError.shareUnavailableInLocalStorage();
   return ShareStore.fromJSON(JSON.parse(foundFile));
 };

--- a/packages/web-storage/src/LocalStorageHelpers.ts
+++ b/packages/web-storage/src/LocalStorageHelpers.ts
@@ -5,7 +5,7 @@ import WebStorageError from "./errors";
 function storageAvailable(type: string): boolean {
   let storage: Storage;
   try {
-    storage = window[type];
+    storage = globalThis[type];
     const x = "__storage_test__";
     storage.setItem(x, x);
     storage.removeItem(x);
@@ -34,14 +34,14 @@ export const storeShareOnLocalStorage = async (share: ShareStore, key: string): 
   if (!storageAvailable("localStorage")) {
     throw WebStorageError.localStorageUnavailable();
   }
-  window.localStorage.setItem(key, fileStr);
+  globalThis.localStorage.setItem(key, fileStr);
 };
 
 export const getShareFromLocalStorage = async (key: string): Promise<ShareStore> => {
   if (!storageAvailable("localStorage")) {
     throw WebStorageError.localStorageUnavailable();
   }
-  const foundFile = window.localStorage.getItem(key);
+  const foundFile = globalThis.localStorage.getItem(key);
   if (!foundFile) throw WebStorageError.shareUnavailableInLocalStorage();
   return ShareStore.fromJSON(JSON.parse(foundFile));
 };

--- a/packages/web-storage/src/WebStorageModule.ts
+++ b/packages/web-storage/src/WebStorageModule.ts
@@ -55,7 +55,7 @@ class WebStorageModule implements IModule {
     await storeShareOnLocalStorage(deviceShareStore, tkeypubx);
     await this.tbSDK.addShareDescription(
       deviceShareStore.share.shareIndex.toString("hex"),
-      JSON.stringify({ module: this.moduleName, userAgent: window.navigator.userAgent, dateAdded: Date.now() }),
+      JSON.stringify({ module: this.moduleName, userAgent: navigator.userAgent, dateAdded: Date.now() }),
       true
     );
   }

--- a/packages/web-storage/src/utils.ts
+++ b/packages/web-storage/src/utils.ts
@@ -1,0 +1,6 @@
+export function getWindow(): Window {
+  if (typeof window !== "undefined") return window;
+  // eslint-disable-next-line no-restricted-globals
+  if (typeof self !== "undefined") return self;
+  throw new Error("Unable to locate window object.");
+}


### PR DESCRIPTION
This replaces direct `window` usage in web storage module, this is an invalid syntax when using in Web Worker syntax, which makes it impossible to offload tkey tasks to Web Worker.

This replaces direct `window` usage to `globalThis` as suggested here:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis