### PR TITLE
Use getWindow at runtime in LocalStorageHelpers.ts

### DIFF
--- a/packages/web-storage/src/LocalStorageHelpers.ts
+++ b/packages/web-storage/src/LocalStorageHelpers.ts
@@ -3,9 +3,8 @@ import { ShareStore } from "@tkey/common-types";
 import WebStorageError from "./errors";
 import { getWindow } from "./utils";
 
-const win = getWindow();
-
 function storageAvailable(type: string): boolean {
+  const win = getWindow();
   let storage: Storage;
   try {
     storage = win[type];
@@ -37,6 +36,7 @@ export const storeShareOnLocalStorage = async (share: ShareStore, key: string): 
   if (!storageAvailable("localStorage")) {
     throw WebStorageError.localStorageUnavailable();
   }
+  const win = getWindow();
   win.localStorage.setItem(key, fileStr);
 };
 
@@ -44,6 +44,7 @@ export const getShareFromLocalStorage = async (key: string): Promise<ShareStore>
   if (!storageAvailable("localStorage")) {
     throw WebStorageError.localStorageUnavailable();
   }
+  const win = getWindow();
   const foundFile = win.localStorage.getItem(key);
   if (!foundFile) throw WebStorageError.shareUnavailableInLocalStorage();
   return ShareStore.fromJSON(JSON.parse(foundFile));


### PR DESCRIPTION
Hi @chaitanyapotti I was looking at this PR #196... I tried it and still got the error _"Unable to locate window object"_. I think it continues because a file is missing to modify to use `getWindow` at runtime.
The file is `packages/web-storage/src/LocalStorageHelpers.ts`

I have an application in Next and with this modification the issues #161 and #194 were solved.