### PR TITLE
feat: return device share; split function

### DIFF
--- a/packages/common-types/src/baseTypes/aggregateTypes.ts
+++ b/packages/common-types/src/baseTypes/aggregateTypes.ts
@@ -131,6 +131,8 @@ export type KeyDetails = {
   threshold: number;
   totalShares: number;
   shareDescriptions: ShareDescriptionMap;
+  deviceShare?: ShareStore;
+  userShare?: ShareStore;
 };
 
 export type TKeyArgs = {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -252,7 +252,6 @@ class ThresholdKey implements ITKey {
         if (neverInitializeNewKey) {
           throw CoreError.default("key has not been generated yet");
         }
-        
 
         // no metadata set, assumes new user
         const newKeyDetails = await this._initializeNewKey({ initializeModules: true, importedKey: importKey, delete1OutOf1: p.delete1OutOf1 });
@@ -267,10 +266,10 @@ class ThresholdKey implements ITKey {
       throw CoreError.default("Input is not supported");
     }
 
-    await this.postInit(shareStore, transitionMetadata, previouslyFetchedCloudMetadata, previousLocalMetadataTransitions);
+    await this.initializeWithShareStore(shareStore, transitionMetadata, previouslyFetchedCloudMetadata, previousLocalMetadataTransitions);
   }
 
-  async postInit(
+  async initializeWithShareStore(
     shareStore: ShareStore,
     transitionMetadata?: Metadata,
     previouslyFetchedCloudMetadata?: Metadata,
@@ -281,8 +280,6 @@ class ThresholdKey implements ITKey {
     const reinitializing = transitionMetadata && previousLocalMetadataTransitionsExists; // are we reinitializing the SDK?
     // in the case we're reinitializing whilst newKeyAssign has not been synced
     const reinitializingWithNewKeyAssign = reinitializing && previouslyFetchedCloudMetadata === undefined;
-
-    
 
     // We determine the latest metadata on the SDK and if there has been
     // needed transitions to include


### PR DESCRIPTION
Tkey should return device share for new user login.
This prevent the share lost when device storage module is not included part of the tkey instantiation

split the `initialize` function to 2 separate function.
Function is too big.