### PR TITLE
fix: initialise with localMetaDataTransition

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -955,6 +955,7 @@ class ThresholdKey implements ITKey {
         const x = transitions[0][i];
         if (params.privKey && x && x.cmp(params.privKey) === 0) index = i;
         else if (params.serviceProvider && !x) index = i;
+        if (index !== null) break;
       }
       if (index !== null) {
         return transitions[1][index];

--- a/packages/default/test/shared.js
+++ b/packages/default/test/shared.js
@@ -1085,19 +1085,20 @@ export const sharedTestCases = (mode, torusSP, storageLayer) => {
     });
   });
 
-  describe("Tkey LocalMetadataTransistion", function () {
-    it("should able to reconstrust with localMetadataTransistion", async function () {
+  describe("Tkey LocalMetadataTransition", function () {
+    it("should able to initialize and reconstruct with localMetadataTransision", async function () {
       const tb = new ThresholdKey({
         serviceProvider: customSP,
         manualSync: true,
         storageLayer: customSL,
       });
 
-      const resp1 = await tb._initializeNewKey();
+      await tb._initializeNewKey();
 
       await tb.reconstructKey(true);
 
-      const newShare = await tb.generateNewShare();
+      const newShareMap = await tb.generateNewShare();
+      const newShare = newShareMap.newShareStores[newShareMap.newShareIndex.toString("hex")];
 
       const localMetadataTransistionShare = tb._localMetadataTransitions[0];
       const localMetadataTransistionData = tb._localMetadataTransitions[1];
@@ -1116,6 +1117,11 @@ export const sharedTestCases = (mode, torusSP, storageLayer) => {
         previousLocalMetadataTransitions: [localMetadataTransistionShare, localMetadataTransistionData],
         // withShare: shareToUseForSerialization,
       });
+
+      await tb2.inputShareStoreSafe(newShare);
+      await tb2.reconstructKey();
+
+      strictEqual(tb.privKey.toString("hex"), tb2.privKey.toString("hex"));
     });
   });
 

--- a/packages/default/test/shared.js
+++ b/packages/default/test/shared.js
@@ -3,6 +3,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
 import { ecCurve, getPubKeyPoint, KEY_NOT_FOUND, SHARE_DELETED } from "@tkey/common-types";
+import { Metadata } from "@tkey/core";
 import PrivateKeyModule, { ED25519Format, SECP256K1Format } from "@tkey/private-keys";
 import SecurityQuestionsModule from "@tkey/security-questions";
 import SeedPhraseModule, { MetamaskSeedPhraseFormat } from "@tkey/seed-phrase";
@@ -1080,6 +1081,40 @@ export const sharedTestCases = (mode, torusSP, storageLayer) => {
       compareReconstructedKeys(reconstructedKey2, {
         privKey: resp1.privKey,
         allKeys: [resp1.privKey],
+      });
+    });
+  });
+
+  describe("Tkey LocalMetadataTransistion", function () {
+    it("should able to reconstrust with localMetadataTransistion", async function () {
+      const tb = new ThresholdKey({
+        serviceProvider: customSP,
+        manualSync: true,
+        storageLayer: customSL,
+      });
+
+      const resp1 = await tb._initializeNewKey();
+
+      await tb.reconstructKey(true);
+
+      const newShare = await tb.generateNewShare();
+
+      const localMetadataTransistionShare = tb._localMetadataTransitions[0];
+      const localMetadataTransistionData = tb._localMetadataTransitions[1];
+
+      const tb2 = new ThresholdKey({
+        serviceProvider: customSP,
+        manualSync: mode,
+        storageLayer: customSL,
+      });
+
+      const newMetadata = Metadata.fromJSON(tb.metadata.toJSON());
+      await tb2.initialize({
+        neverInitializeNewKey: true,
+        transitionMetadata: newMetadata,
+        // previouslyFetchedCloudMetadata: tempCloud,
+        previousLocalMetadataTransitions: [localMetadataTransistionShare, localMetadataTransistionData],
+        // withShare: shareToUseForSerialization,
       });
     });
   });


### PR DESCRIPTION
during tkey initialisation with localMetadataTransition, tkey get the transitionData of the eldest transition instead of latest transition from the function `getGenericMetadataWithTransitionStates`
