### PR TITLE
Add SFA Service Provider 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25139,16 +25139,16 @@
     },
     "packages/service-provider-sfa": {
       "name": "@tkey/service-provider-sfa",
-      "version": "12.0.0",
+      "version": "13.0.0-alpha.4",
       "license": "MIT",
       "dependencies": {
-        "@tkey/service-provider-base": "^12.0.0",
-        "@toruslabs/fetch-node-details": "^13.0.4",
-        "@toruslabs/torus.js": "^12.0.1",
+        "@tkey/service-provider-base": "^13.0.0-alpha.4",
+        "@toruslabs/fetch-node-details": "^13.4.0",
+        "@toruslabs/torus.js": "^12.3.6",
         "bn.js": "^5.2.1"
       },
       "devDependencies": {
-        "@types/bn.js": "^5.1.2"
+        "@types/bn.js": "^5.1.5"
       },
       "engines": {
         "node": ">=18.x",
@@ -25156,79 +25156,6 @@
       },
       "peerDependencies": {
         "@babel/runtime": "7.x"
-      }
-    },
-    "packages/service-provider-sfa/node_modules/@tkey/common-types": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@tkey/common-types/-/common-types-12.1.2.tgz",
-      "integrity": "sha512-Cat3qT34AeiR8HvVYW+sAR5b9dlKlRUShsGThKoxe9u5ppZK4othNlnFZ7921+kclB/gLAtoAXQp9pjtQncJ3A==",
-      "dependencies": {
-        "@toruslabs/customauth": "^18.1.0",
-        "@toruslabs/eccrypto": "^4.0.0",
-        "@toruslabs/torus.js": "^12.3.6",
-        "bn.js": "^5.2.1",
-        "elliptic": "^6.5.5",
-        "serialize-error": "^8.1.0",
-        "ts-custom-error": "^3.3.1"
-      },
-      "engines": {
-        "node": ">=18.x",
-        "npm": ">=9.x"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "7.x"
-      }
-    },
-    "packages/service-provider-sfa/node_modules/@tkey/service-provider-base": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@tkey/service-provider-base/-/service-provider-base-12.1.2.tgz",
-      "integrity": "sha512-mPY3AuyX4coNVWEu4echuI2brAAMCNv8dIM5+n8HUSNgOk0nOirzz2v0TqGs1BNWiYq2eKIBtpOuF5n2rFY7mw==",
-      "dependencies": {
-        "@tkey/common-types": "^12.1.2",
-        "bn.js": "^5.2.1",
-        "elliptic": "^6.5.5"
-      },
-      "engines": {
-        "node": ">=18.x",
-        "npm": ">=9.x"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "7.x"
-      }
-    },
-    "packages/service-provider-sfa/node_modules/@toruslabs/customauth": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@toruslabs/customauth/-/customauth-18.1.0.tgz",
-      "integrity": "sha512-cXNXkv2DOZu+XQc0ZEqzPwQJWTXkdxTKz9/uzVsF1i9A6KyrTupX1yN8k/mXZybLJ2R3cz1/e9iezn1NPhUPiA==",
-      "dependencies": {
-        "@chaitanyapotti/register-service-worker": "^1.7.4",
-        "@toruslabs/broadcast-channel": "^10.0.2",
-        "@toruslabs/constants": "^13.2.0",
-        "@toruslabs/eccrypto": "^4.0.0",
-        "@toruslabs/fetch-node-details": "^13.2.0",
-        "@toruslabs/http-helpers": "^6.1.0",
-        "@toruslabs/metadata-helpers": "^5.1.0",
-        "@toruslabs/openlogin-session-manager": "^3.1.1",
-        "@toruslabs/torus.js": "^12.2.0",
-        "base64url": "^3.0.1",
-        "bowser": "^2.11.0",
-        "events": "^3.3.0",
-        "jwt-decode": "^4.0.0",
-        "lodash.merge": "^4.6.2",
-        "loglevel": "^1.9.1"
-      },
-      "engines": {
-        "node": ">=18.x",
-        "npm": ">=9.x"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "^7.x",
-        "@sentry/types": "^7.x"
-      },
-      "peerDependenciesMeta": {
-        "@sentry/types": {
-          "optional": true
-        }
       }
     },
     "packages/service-provider-sfa/node_modules/@toruslabs/torus.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4375,6 +4375,10 @@
       "resolved": "packages/service-provider-base",
       "link": true
     },
+    "node_modules/@tkey/service-provider-sfa": {
+      "resolved": "packages/service-provider-sfa",
+      "link": true
+    },
     "node_modules/@tkey/service-provider-torus": {
       "resolved": "packages/service-provider-torus",
       "link": true
@@ -25124,6 +25128,122 @@
       "devDependencies": {
         "@types/bn.js": "^5.1.5",
         "@types/elliptic": "^6.4.18"
+      },
+      "engines": {
+        "node": ">=18.x",
+        "npm": ">=9.x"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "7.x"
+      }
+    },
+    "packages/service-provider-sfa": {
+      "name": "@tkey/service-provider-sfa",
+      "version": "12.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@tkey/service-provider-base": "^12.0.0",
+        "@toruslabs/fetch-node-details": "^13.0.4",
+        "@toruslabs/torus.js": "^12.0.1",
+        "bn.js": "^5.2.1"
+      },
+      "devDependencies": {
+        "@types/bn.js": "^5.1.2"
+      },
+      "engines": {
+        "node": ">=18.x",
+        "npm": ">=9.x"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "7.x"
+      }
+    },
+    "packages/service-provider-sfa/node_modules/@tkey/common-types": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@tkey/common-types/-/common-types-12.1.2.tgz",
+      "integrity": "sha512-Cat3qT34AeiR8HvVYW+sAR5b9dlKlRUShsGThKoxe9u5ppZK4othNlnFZ7921+kclB/gLAtoAXQp9pjtQncJ3A==",
+      "dependencies": {
+        "@toruslabs/customauth": "^18.1.0",
+        "@toruslabs/eccrypto": "^4.0.0",
+        "@toruslabs/torus.js": "^12.3.6",
+        "bn.js": "^5.2.1",
+        "elliptic": "^6.5.5",
+        "serialize-error": "^8.1.0",
+        "ts-custom-error": "^3.3.1"
+      },
+      "engines": {
+        "node": ">=18.x",
+        "npm": ">=9.x"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "7.x"
+      }
+    },
+    "packages/service-provider-sfa/node_modules/@tkey/service-provider-base": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@tkey/service-provider-base/-/service-provider-base-12.1.2.tgz",
+      "integrity": "sha512-mPY3AuyX4coNVWEu4echuI2brAAMCNv8dIM5+n8HUSNgOk0nOirzz2v0TqGs1BNWiYq2eKIBtpOuF5n2rFY7mw==",
+      "dependencies": {
+        "@tkey/common-types": "^12.1.2",
+        "bn.js": "^5.2.1",
+        "elliptic": "^6.5.5"
+      },
+      "engines": {
+        "node": ">=18.x",
+        "npm": ">=9.x"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "7.x"
+      }
+    },
+    "packages/service-provider-sfa/node_modules/@toruslabs/customauth": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@toruslabs/customauth/-/customauth-18.1.0.tgz",
+      "integrity": "sha512-cXNXkv2DOZu+XQc0ZEqzPwQJWTXkdxTKz9/uzVsF1i9A6KyrTupX1yN8k/mXZybLJ2R3cz1/e9iezn1NPhUPiA==",
+      "dependencies": {
+        "@chaitanyapotti/register-service-worker": "^1.7.4",
+        "@toruslabs/broadcast-channel": "^10.0.2",
+        "@toruslabs/constants": "^13.2.0",
+        "@toruslabs/eccrypto": "^4.0.0",
+        "@toruslabs/fetch-node-details": "^13.2.0",
+        "@toruslabs/http-helpers": "^6.1.0",
+        "@toruslabs/metadata-helpers": "^5.1.0",
+        "@toruslabs/openlogin-session-manager": "^3.1.1",
+        "@toruslabs/torus.js": "^12.2.0",
+        "base64url": "^3.0.1",
+        "bowser": "^2.11.0",
+        "events": "^3.3.0",
+        "jwt-decode": "^4.0.0",
+        "lodash.merge": "^4.6.2",
+        "loglevel": "^1.9.1"
+      },
+      "engines": {
+        "node": ">=18.x",
+        "npm": ">=9.x"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.x",
+        "@sentry/types": "^7.x"
+      },
+      "peerDependenciesMeta": {
+        "@sentry/types": {
+          "optional": true
+        }
+      }
+    },
+    "packages/service-provider-sfa/node_modules/@toruslabs/torus.js": {
+      "version": "12.3.6",
+      "resolved": "https://registry.npmjs.org/@toruslabs/torus.js/-/torus.js-12.3.6.tgz",
+      "integrity": "sha512-cXPC+Cyw4W05eZW784pPd+QyJRmvK54wTYbBocU9gVaqZhGXNryVrqhBYZSOmAr3pUtOubjRZfeXCZLn7BA77Q==",
+      "dependencies": {
+        "@toruslabs/constants": "^13.4.0",
+        "@toruslabs/eccrypto": "^4.0.0",
+        "@toruslabs/http-helpers": "^6.1.1",
+        "bn.js": "^5.2.1",
+        "elliptic": "^6.5.5",
+        "ethereum-cryptography": "^2.1.3",
+        "json-stable-stringify": "^1.1.1",
+        "loglevel": "^1.9.1"
       },
       "engines": {
         "node": ">=18.x",

--- a/packages/common-types/src/baseTypes/commonTypes.ts
+++ b/packages/common-types/src/baseTypes/commonTypes.ts
@@ -49,8 +49,8 @@ export interface IServiceProvider extends ISerializable {
   postboxKey: BN;
 
   serviceProviderName: string;
-  
-  migratableKey? : BN | null;
+
+  migratableKey?: BN | null;
 
   encrypt(msg: Buffer): Promise<EncryptedMessage>;
   decrypt(msg: EncryptedMessage): Promise<Buffer>;

--- a/packages/common-types/src/baseTypes/commonTypes.ts
+++ b/packages/common-types/src/baseTypes/commonTypes.ts
@@ -49,6 +49,8 @@ export interface IServiceProvider extends ISerializable {
   postboxKey: BN;
 
   serviceProviderName: string;
+  
+  migratableKey? : BN | null;
 
   encrypt(msg: Buffer): Promise<EncryptedMessage>;
   decrypt(msg: EncryptedMessage): Promise<Buffer>;

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -277,7 +277,7 @@ class ThresholdKey implements ITKey {
           const tempStateManualSync = this.manualSync;
           this.manualSync = true;
           await this._initializeNewKey({ initializeModules: true, importedKey: this.serviceProvider.migratableKey, delete1OutOf1: true });
-          this.syncLocalMetadataTransitions();
+          await this.syncLocalMetadataTransitions();
           // restore manual sync flag
           this.manualSync = tempStateManualSync;
         } else {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -277,7 +277,7 @@ class ThresholdKey implements ITKey {
           const tempStateManualSync = this.manualSync;
           this.manualSync = true;
           await this._initializeNewKey({ initializeModules: true, importedKey: this.serviceProvider.migratableKey, delete1OutOf1: true });
-          await this.syncLocalMetadataTransitions();
+          if (!tempStateManualSync) await this.syncLocalMetadataTransitions(); // Only sync if we were not in manual sync mode
           // restore manual sync flag
           this.manualSync = tempStateManualSync;
         } else {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -274,10 +274,10 @@ class ThresholdKey implements ITKey {
         // provided no importKey is provided ( importKey take precedent )
         if (this.serviceProvider.migratableKey && !importKey) {
           // importkey from server provider need to be atomic, hence manual sync is required.
-          const tempStateManualSync = this.manualSync;
-          this.manualSync = true;
+          const tempStateManualSync = this.manualSync; // temp store manual sync flag
+          this.manualSync = true; // Setting this as true since _initializeNewKey has a check where for importkey from server provider need to be atomic, hence manual sync is required.
           await this._initializeNewKey({ initializeModules: true, importedKey: this.serviceProvider.migratableKey, delete1OutOf1: true });
-          if (!tempStateManualSync) await this.syncLocalMetadataTransitions(); // Only sync if we were not in manual sync mode
+          if (!tempStateManualSync) await this.syncLocalMetadataTransitions(); // Only sync if we were not in manual sync mode, if manual sync is set by developer, they should handle it themselves
           // restore manual sync flag
           this.manualSync = tempStateManualSync;
         } else {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -267,13 +267,29 @@ class ThresholdKey implements ITKey {
         if (neverInitializeNewKey) {
           throw CoreError.default("key has not been generated yet");
         }
+
         // no metadata set, assumes new user
-        await this._initializeNewKey({
-          initializeModules: true,
-          importedKey: importKey,
-          importEd25519Seed: params?.importEd25519Seed,
-          delete1OutOf1: p.delete1OutOf1,
-        });
+
+        // check for serviceprovider migratableKey for import key from service provider for new user
+        // provided no importKey is provided ( importKey take precedent )
+        if (this.serviceProvider.migratableKey && !importKey) {
+          // importkey from server provider need to be atomic, hence manual sync is required.
+          const tempStateManualSync = this.manualSync;
+          this.manualSync = true;
+          await this._initializeNewKey({ initializeModules: true, importedKey: this.serviceProvider.migratableKey, delete1OutOf1: true });
+          this.syncLocalMetadataTransitions();
+          // restore manual sync flag
+          this.manualSync = tempStateManualSync;
+        } else {
+          await this._initializeNewKey({ 
+            initializeModules: true, 
+            importedKey: importKey, 
+            delete1OutOf1: p.delete1OutOf1, 
+            importEd25519Seed: params?.importEd25519Seed,
+          });
+        }
+
+        // return after created new tkey account ( skip other steps)
         return this.getKeyDetails();
       }
       // else we continue with catching up share and metadata

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -281,10 +281,10 @@ class ThresholdKey implements ITKey {
           // restore manual sync flag
           this.manualSync = tempStateManualSync;
         } else {
-          await this._initializeNewKey({ 
-            initializeModules: true, 
-            importedKey: importKey, 
-            delete1OutOf1: p.delete1OutOf1, 
+          await this._initializeNewKey({
+            initializeModules: true,
+            importedKey: importKey,
+            delete1OutOf1: p.delete1OutOf1,
             importEd25519Seed: params?.importEd25519Seed,
           });
         }

--- a/packages/service-provider-base/src/ServiceProviderBase.ts
+++ b/packages/service-provider-base/src/ServiceProviderBase.ts
@@ -22,6 +22,8 @@ class ServiceProviderBase implements IServiceProvider {
 
   serviceProviderName: string;
 
+  migratableKey: BN | null = null;
+
   constructor({ enableLogging = false, postboxKey }: ServiceProviderArgs) {
     this.enableLogging = enableLogging;
     this.postboxKey = new BN(postboxKey, "hex");

--- a/packages/service-provider-sfa/README.md
+++ b/packages/service-provider-sfa/README.md
@@ -1,0 +1,27 @@
+# tKey Single Factor Auth Service Provider
+
+[![npm version](https://img.shields.io/npm/v/@tkey/service-provider-sfa?label=%22%22)](https://www.npmjs.com/package/@tkey/service-provider-sfa/v/latest) [![minzip](https://img.shields.io/bundlephobia/minzip/@tkey/service-provider-sfa?label=%22%22)](https://bundlephobia.com/result?p=@tkey/service-provider-sfa@latest)
+
+Service Provider in `tKey` is used for generating a social login share of the private key share managed by a wallet service provider via
+their own authentication flows.
+
+## Installation
+
+```shell
+npm install --save @tkey/service-provider-sfa
+```
+
+### See the full [SDK Reference](https://web3auth.io/docs/sdk/core-kit/tkey/usage#log-in) on the Web3Auth Documentation
+
+## Example
+
+```js
+import SFAServiceProvider from '@tkey/service-provider-sfa';
+
+const web3AuthOptions: any = {
+  clientId, // Get your Client ID from Web3Auth Dashboard
+  web3AuthNetwork: 'testnet', // ["cyan", "testnet", "mainnet", "aqua", "sapphire_devnet", "sapphire_mainnet"]
+};
+
+const serviceProvider = new SFAServiceProvider({web3AuthOptions});
+```

--- a/packages/service-provider-sfa/package.json
+++ b/packages/service-provider-sfa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tkey/service-provider-sfa",
-  "version": "12.0.0",
+  "version": "13.0.0-alpha.4",
   "description": "TKey Torus Service Provider Module",
   "author": "Torus Labs",
   "homepage": "https://github.com/tkey/tkey#readme",
@@ -38,13 +38,13 @@
     "@babel/runtime": "7.x"
   },
   "dependencies": {
-    "@tkey/service-provider-base": "^12.0.0",
-    "@toruslabs/fetch-node-details": "^13.0.4",
-    "@toruslabs/torus.js": "^12.0.1",
+    "@tkey/service-provider-base": "^13.0.0-alpha.4",
+    "@toruslabs/fetch-node-details": "^13.4.0",
+    "@toruslabs/torus.js": "^12.3.6",
     "bn.js": "^5.2.1"
   },
   "devDependencies": {
-    "@types/bn.js": "^5.1.2"
+    "@types/bn.js": "^5.1.5"
   },
   "bugs": {
     "url": "https://github.com/tkey/tkey/issues"

--- a/packages/service-provider-sfa/package.json
+++ b/packages/service-provider-sfa/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@tkey/service-provider-sfa",
+  "version": "12.0.0",
+  "description": "TKey Torus Service Provider Module",
+  "author": "Torus Labs",
+  "homepage": "https://github.com/tkey/tkey#readme",
+  "license": "MIT",
+  "main": "dist/serviceProviderSfa.cjs.js",
+  "module": "dist/serviceProviderSfa.esm.js",
+  "unpkg": "dist/serviceProviderSfa.umd.min.js",
+  "jsdelivr": "dist/serviceProviderSfa.umd.min.js",
+  "types": "dist/types/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tkey/tkey.git"
+  },
+  "scripts": {
+    "test": "cross-env MOCKED=true mocha --config ../../.mocharc.json ",
+    "coverage": "nyc npm test",
+    "coverage-production": "nyc npm run test-production",
+    "test-development": "cross-env MOCKED=false METADATA=http://localhost:5051 mocha --config ../../.mocharc.json ",
+    "test-production": "cross-env MOCKED=false METADATA=https://metadata.tor.us mocha --config ../../.mocharc.json ",
+    "test-debugger": "mocha --config ../../.mocharc.json --inspect-brk",
+    "dev": "rimraf dist/ && cross-env NODE_ENV=development torus-scripts build",
+    "build": "rimraf dist/ && cross-env NODE_ENV=production torus-scripts build",
+    "lint": "eslint --fix 'src/**/*.ts'",
+    "prepack": "npm run build",
+    "pre-commit": "lint-staged"
+  },
+  "peerDependencies": {
+    "@babel/runtime": "7.x"
+  },
+  "dependencies": {
+    "@tkey/service-provider-base": "^12.0.0",
+    "@toruslabs/fetch-node-details": "^13.0.4",
+    "@toruslabs/torus.js": "^12.0.1",
+    "bn.js": "^5.2.1"
+  },
+  "devDependencies": {
+    "@types/bn.js": "^5.1.2"
+  },
+  "bugs": {
+    "url": "https://github.com/tkey/tkey/issues"
+  },
+  "lint-staged": {
+    "!(*d).ts": [
+      "npm run lint --",
+      "prettier --write 'src/**/*.ts'"
+    ]
+  },
+  "engines": {
+    "node": ">=18.x",
+    "npm": ">=9.x"
+  },
+  "gitHead": "9967ce9f795f495f28ef0da1fc50acde31dcc258"
+}

--- a/packages/service-provider-sfa/src/SfaServiceProvider.ts
+++ b/packages/service-provider-sfa/src/SfaServiceProvider.ts
@@ -1,0 +1,94 @@
+import { type StringifiedType } from "@tkey/common-types";
+import { ServiceProviderBase } from "@tkey/service-provider-base";
+import { NodeDetailManager } from "@toruslabs/fetch-node-details";
+import Torus, { keccak256, TorusKey } from "@toruslabs/torus.js";
+import BN from "bn.js";
+
+import { AggregateVerifierParams, LoginParams, SfaServiceProviderArgs, Web3AuthOptions } from "./interfaces";
+
+class SfaServiceProvider extends ServiceProviderBase {
+  web3AuthOptions: Web3AuthOptions;
+
+  authInstance: Torus;
+
+  public torusKey: TorusKey;
+
+  private nodeDetailManagerInstance: NodeDetailManager;
+
+  constructor({ enableLogging = false, postboxKey, web3AuthOptions }: SfaServiceProviderArgs) {
+    super({ enableLogging, postboxKey });
+    this.web3AuthOptions = web3AuthOptions;
+    this.authInstance = new Torus({
+      clientId: web3AuthOptions.clientId,
+      enableOneKey: true,
+      network: web3AuthOptions.network,
+    });
+    Torus.enableLogging(enableLogging);
+    this.serviceProviderName = "SfaServiceProvider";
+    this.nodeDetailManagerInstance = new NodeDetailManager({ network: web3AuthOptions.network, enableLogging });
+  }
+
+  static fromJSON(value: StringifiedType): SfaServiceProvider {
+    const { enableLogging, postboxKey, web3AuthOptions, serviceProviderName, torusKey } = value;
+    if (serviceProviderName !== "SfaServiceProvider") return undefined;
+
+    const sfaSP = new SfaServiceProvider({
+      enableLogging,
+      postboxKey,
+      web3AuthOptions,
+    });
+
+    sfaSP.torusKey = torusKey;
+
+    return sfaSP;
+  }
+
+  async connect(params: LoginParams): Promise<BN> {
+    const { verifier, verifierId, idToken, subVerifierInfoArray } = params;
+    const verifierDetails = { verifier, verifierId };
+
+    // fetch node details.
+    const { torusNodeEndpoints, torusNodePub, torusIndexes } = await this.nodeDetailManagerInstance.getNodeDetails(verifierDetails);
+
+    if (params.serverTimeOffset) {
+      this.authInstance.serverTimeOffset = params.serverTimeOffset;
+    }
+    // Does the key assign
+    if (this.authInstance.isLegacyNetwork) await this.authInstance.getPublicAddress(torusNodeEndpoints, torusNodePub, { verifier, verifierId });
+
+    let finalIdToken = idToken;
+    let finalVerifierParams = { verifier_id: verifierId };
+    if (subVerifierInfoArray && subVerifierInfoArray?.length > 0) {
+      const aggregateVerifierParams: AggregateVerifierParams = { verify_params: [], sub_verifier_ids: [], verifier_id: "" };
+      const aggregateIdTokenSeeds = [];
+      for (let index = 0; index < subVerifierInfoArray.length; index += 1) {
+        const userInfo = subVerifierInfoArray[index];
+        aggregateVerifierParams.verify_params.push({ verifier_id: verifierId, idtoken: userInfo.idToken });
+        aggregateVerifierParams.sub_verifier_ids.push(userInfo.verifier);
+        aggregateIdTokenSeeds.push(userInfo.idToken);
+      }
+      aggregateIdTokenSeeds.sort();
+
+      finalIdToken = keccak256(Buffer.from(aggregateIdTokenSeeds.join(String.fromCharCode(29)), "utf8")).slice(2);
+
+      aggregateVerifierParams.verifier_id = verifierId;
+      finalVerifierParams = aggregateVerifierParams;
+    }
+
+    const torusKey = await this.authInstance.retrieveShares(torusNodeEndpoints, torusIndexes, verifier, finalVerifierParams, finalIdToken);
+    this.torusKey = torusKey;
+    const postboxKey = Torus.getPostboxKey(torusKey);
+    this.postboxKey = new BN(postboxKey, 16);
+    return this.postboxKey;
+  }
+
+  toJSON(): StringifiedType {
+    return {
+      ...super.toJSON(),
+      serviceProviderName: this.serviceProviderName,
+      web3AuthOptions: this.web3AuthOptions,
+    };
+  }
+}
+
+export default SfaServiceProvider;

--- a/packages/service-provider-sfa/src/SfaServiceProvider.ts
+++ b/packages/service-provider-sfa/src/SfaServiceProvider.ts
@@ -50,13 +50,13 @@ class SfaServiceProvider extends ServiceProviderBase {
     const verifierDetails = { verifier, verifierId };
 
     // fetch node details.
-    const { torusNodeEndpoints, torusNodePub, torusIndexes } = await this.nodeDetailManagerInstance.getNodeDetails(verifierDetails);
+    const { torusNodeEndpoints, torusIndexes } = await this.nodeDetailManagerInstance.getNodeDetails(verifierDetails);
 
     if (params.serverTimeOffset) {
       this.authInstance.serverTimeOffset = params.serverTimeOffset;
     }
     // Does the key assign
-    if (this.authInstance.isLegacyNetwork) await this.authInstance.getPublicAddress(torusNodeEndpoints, torusNodePub, { verifier, verifierId });
+    // if (this.authInstance.isLegacyNetwork) await this.authInstance.getPublicAddress(torusNodeEndpoints, torusNodePub, { verifier, verifierId });
 
     let finalIdToken = idToken;
     let finalVerifierParams = { verifier_id: verifierId };

--- a/packages/service-provider-sfa/src/SfaServiceProvider.ts
+++ b/packages/service-provider-sfa/src/SfaServiceProvider.ts
@@ -13,7 +13,7 @@ class SfaServiceProvider extends ServiceProviderBase {
 
   public torusKey: TorusKey;
 
-  public migratableKey: BN | null = null;
+  public migratableKey: BN | null = null; // Migration of key from SFA to tKey
 
   private nodeDetailManagerInstance: NodeDetailManager;
 
@@ -79,10 +79,10 @@ class SfaServiceProvider extends ServiceProviderBase {
 
     const torusKey = await this.authInstance.retrieveShares(torusNodeEndpoints, torusIndexes, verifier, finalVerifierParams, finalIdToken);
     this.torusKey = torusKey;
-    const { finalKeyData, oAuthKeyData } = torusKey;
-    const privKey = finalKeyData.privKey || oAuthKeyData.privKey;
 
     if (!torusKey.metadata.upgraded) {
+      const { finalKeyData, oAuthKeyData } = torusKey;
+      const privKey = finalKeyData.privKey || oAuthKeyData.privKey;
       this.migratableKey = new BN(privKey, "hex");
     }
     const postboxKey = Torus.getPostboxKey(torusKey);

--- a/packages/service-provider-sfa/src/SfaServiceProvider.ts
+++ b/packages/service-provider-sfa/src/SfaServiceProvider.ts
@@ -13,6 +13,8 @@ class SfaServiceProvider extends ServiceProviderBase {
 
   public torusKey: TorusKey;
 
+  public migratableKey: BN | null = null;
+
   private nodeDetailManagerInstance: NodeDetailManager;
 
   constructor({ enableLogging = false, postboxKey, web3AuthOptions }: SfaServiceProviderArgs) {
@@ -77,6 +79,12 @@ class SfaServiceProvider extends ServiceProviderBase {
 
     const torusKey = await this.authInstance.retrieveShares(torusNodeEndpoints, torusIndexes, verifier, finalVerifierParams, finalIdToken);
     this.torusKey = torusKey;
+    const { finalKeyData, oAuthKeyData } = torusKey;
+    const privKey = finalKeyData.privKey || oAuthKeyData.privKey;
+
+    if (!torusKey.metadata.upgraded) {
+      this.migratableKey = new BN(privKey, "hex");
+    }
     const postboxKey = Torus.getPostboxKey(torusKey);
     this.postboxKey = new BN(postboxKey, 16);
     return this.postboxKey;

--- a/packages/service-provider-sfa/src/SfaServiceProvider.ts
+++ b/packages/service-provider-sfa/src/SfaServiceProvider.ts
@@ -55,8 +55,6 @@ class SfaServiceProvider extends ServiceProviderBase {
     if (params.serverTimeOffset) {
       this.authInstance.serverTimeOffset = params.serverTimeOffset;
     }
-    // Does the key assign
-    // if (this.authInstance.isLegacyNetwork) await this.authInstance.getPublicAddress(torusNodeEndpoints, torusNodePub, { verifier, verifierId });
 
     let finalIdToken = idToken;
     let finalVerifierParams = { verifier_id: verifierId };

--- a/packages/service-provider-sfa/src/index.ts
+++ b/packages/service-provider-sfa/src/index.ts
@@ -1,0 +1,1 @@
+export { default, default as SfaServiceProvider } from "./SfaServiceProvider";

--- a/packages/service-provider-sfa/src/interfaces.ts
+++ b/packages/service-provider-sfa/src/interfaces.ts
@@ -1,0 +1,30 @@
+import { type ServiceProviderArgs } from "@tkey/common-types";
+import { type TORUS_NETWORK_TYPE } from "@toruslabs/constants";
+
+export interface Web3AuthOptions {
+  clientId: string;
+  network: TORUS_NETWORK_TYPE;
+}
+export interface SfaServiceProviderArgs extends ServiceProviderArgs {
+  web3AuthOptions: Web3AuthOptions;
+}
+
+export interface TorusSubVerifierInfo {
+  verifier: string;
+  idToken: string;
+}
+
+export type AggregateVerifierParams = {
+  verify_params: { verifier_id: string; idtoken: string }[];
+  sub_verifier_ids: string[];
+  verifier_id: string;
+};
+
+export type LoginParams = {
+  verifier: string;
+  verifierId: string;
+  idToken: string;
+  subVerifierInfoArray?: TorusSubVerifierInfo[];
+  // offset in seconds
+  serverTimeOffset?: number;
+};

--- a/packages/service-provider-sfa/test/.eslintrc.json
+++ b/packages/service-provider-sfa/test/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+    "prefer-arrow-callback": "off",
+    "func-names": "off"
+  }
+  
+}

--- a/packages/service-provider-sfa/torus.config.js
+++ b/packages/service-provider-sfa/torus.config.js
@@ -1,0 +1,1 @@
+module.exports = require("../../torus.config");

--- a/packages/service-provider-sfa/tsconfig.json
+++ b/packages/service-provider-sfa/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "test"]
+}

--- a/packages/service-provider-sfa/webpack.config.js
+++ b/packages/service-provider-sfa/webpack.config.js
@@ -1,0 +1,6 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const generateWebpackConfig = require("../../webpack.config");
+
+const config = generateWebpackConfig({  });
+
+exports.baseConfig = config.baseConfig;

--- a/packages/service-provider-torus/src/TorusServiceProvider.ts
+++ b/packages/service-provider-torus/src/TorusServiceProvider.ts
@@ -75,19 +75,11 @@ class TorusServiceProvider extends ServiceProviderBase {
   async triggerAggregateLogin(params: AggregateLoginParams): Promise<TorusAggregateLoginResponse> {
     const obj = await this.customAuthInstance.triggerAggregateLogin(params);
 
-    // `obj` maybe `null` in redirect mode.
-    if (obj) {
-      const localPrivKey = Torus.getPostboxKey(obj);
-      this.torusKey = obj;
-      const { finalKeyData, oAuthKeyData } = obj;
-      const privKey = finalKeyData.privKey || oAuthKeyData.privKey;
-
-      if (!obj.metadata.upgraded) {
-        this.migratableKey = new BN(privKey, "hex");
-      }
-    
-      this.postboxKey = new BN(localPrivKey, "hex");
+    if (!obj.metadata.upgraded) {
+      this.migratableKey = new BN(privKey, "hex");
     }
+
+    this.postboxKey = new BN(localPrivKey, "hex");
     return obj;
   }
 

--- a/packages/service-provider-torus/src/TorusServiceProvider.ts
+++ b/packages/service-provider-torus/src/TorusServiceProvider.ts
@@ -10,13 +10,15 @@ import CustomAuth, {
   TorusHybridAggregateLoginResponse,
   TorusLoginResponse,
 } from "@toruslabs/customauth";
-import Torus from "@toruslabs/torus.js";
+import Torus, { TorusKey } from "@toruslabs/torus.js";
 import BN from "bn.js";
 
 class TorusServiceProvider extends ServiceProviderBase {
   customAuthInstance: CustomAuth;
 
   singleLoginKey: BN;
+
+  public torusKey: TorusKey;
 
   customAuthArgs: CustomAuthArgs;
 
@@ -51,6 +53,7 @@ class TorusServiceProvider extends ServiceProviderBase {
     // `obj` maybe `null` in redirect mode.
     if (obj) {
       const localPrivKey = Torus.getPostboxKey(obj);
+      this.torusKey = obj;
       this.postboxKey = new BN(localPrivKey, "hex");
     }
 
@@ -66,6 +69,7 @@ class TorusServiceProvider extends ServiceProviderBase {
     // `obj` maybe `null` in redirect mode.
     if (obj) {
       const localPrivKey = Torus.getPostboxKey(obj);
+      this.torusKey = obj;
       this.postboxKey = new BN(localPrivKey, "hex");
     }
     return obj;
@@ -81,6 +85,7 @@ class TorusServiceProvider extends ServiceProviderBase {
     if (obj) {
       const aggregateLoginKey = Torus.getPostboxKey(obj.aggregateLogins[0]);
       const singleLoginKey = Torus.getPostboxKey(obj.singleLogin);
+      this.torusKey = null;
       this.postboxKey = new BN(aggregateLoginKey, "hex");
       this.singleLoginKey = new BN(singleLoginKey, "hex");
     }

--- a/packages/service-provider-torus/src/TorusServiceProvider.ts
+++ b/packages/service-provider-torus/src/TorusServiceProvider.ts
@@ -20,6 +20,8 @@ class TorusServiceProvider extends ServiceProviderBase {
 
   public torusKey: TorusKey;
 
+  public migratableKey: BN | null = null;
+
   customAuthArgs: CustomAuthArgs;
 
   constructor({ enableLogging = false, postboxKey, customAuthArgs }: TorusServiceProviderArgs) {
@@ -54,6 +56,13 @@ class TorusServiceProvider extends ServiceProviderBase {
     if (obj) {
       const localPrivKey = Torus.getPostboxKey(obj);
       this.torusKey = obj;
+      const { finalKeyData, oAuthKeyData } = obj;
+      const privKey = finalKeyData.privKey || oAuthKeyData.privKey;
+  
+      if (!obj.metadata.upgraded) {
+        this.migratableKey = new BN(privKey, "hex");
+      }
+  
       this.postboxKey = new BN(localPrivKey, "hex");
     }
 
@@ -70,6 +79,13 @@ class TorusServiceProvider extends ServiceProviderBase {
     if (obj) {
       const localPrivKey = Torus.getPostboxKey(obj);
       this.torusKey = obj;
+      const { finalKeyData, oAuthKeyData } = obj;
+      const privKey = finalKeyData.privKey || oAuthKeyData.privKey;
+
+      if (!obj.metadata.upgraded) {
+        this.migratableKey = new BN(privKey, "hex");
+      }
+    
       this.postboxKey = new BN(localPrivKey, "hex");
     }
     return obj;

--- a/packages/service-provider-torus/src/TorusServiceProvider.ts
+++ b/packages/service-provider-torus/src/TorusServiceProvider.ts
@@ -75,11 +75,18 @@ class TorusServiceProvider extends ServiceProviderBase {
   async triggerAggregateLogin(params: AggregateLoginParams): Promise<TorusAggregateLoginResponse> {
     const obj = await this.customAuthInstance.triggerAggregateLogin(params);
 
-    if (!obj.metadata.upgraded) {
-      this.migratableKey = new BN(privKey, "hex");
-    }
+    if (obj) {
+      const localPrivKey = Torus.getPostboxKey(obj);
+      this.torusKey = obj;
+      const { finalKeyData, oAuthKeyData } = obj;
+      const privKey = finalKeyData.privKey || oAuthKeyData.privKey;
 
-    this.postboxKey = new BN(localPrivKey, "hex");
+      if (!obj.metadata.upgraded) {
+        this.migratableKey = new BN(privKey, "hex");
+      }
+
+      this.postboxKey = new BN(localPrivKey, "hex");
+    }
     return obj;
   }
 

--- a/packages/service-provider-torus/src/TorusServiceProvider.ts
+++ b/packages/service-provider-torus/src/TorusServiceProvider.ts
@@ -20,7 +20,7 @@ class TorusServiceProvider extends ServiceProviderBase {
 
   public torusKey: TorusKey;
 
-  public migratableKey: BN | null = null;
+  public migratableKey: BN | null = null; // Migration of key from SFA to tKey
 
   customAuthArgs: CustomAuthArgs;
 

--- a/packages/service-provider-torus/src/TorusServiceProvider.ts
+++ b/packages/service-provider-torus/src/TorusServiceProvider.ts
@@ -58,11 +58,11 @@ class TorusServiceProvider extends ServiceProviderBase {
       this.torusKey = obj;
       const { finalKeyData, oAuthKeyData } = obj;
       const privKey = finalKeyData.privKey || oAuthKeyData.privKey;
-  
+
       if (!obj.metadata.upgraded) {
         this.migratableKey = new BN(privKey, "hex");
       }
-  
+
       this.postboxKey = new BN(localPrivKey, "hex");
     }
 

--- a/packages/service-provider-torus/src/TorusServiceProvider.ts
+++ b/packages/service-provider-torus/src/TorusServiceProvider.ts
@@ -56,10 +56,10 @@ class TorusServiceProvider extends ServiceProviderBase {
     if (obj) {
       const localPrivKey = Torus.getPostboxKey(obj);
       this.torusKey = obj;
-      const { finalKeyData, oAuthKeyData } = obj;
-      const privKey = finalKeyData.privKey || oAuthKeyData.privKey;
 
       if (!obj.metadata.upgraded) {
+        const { finalKeyData, oAuthKeyData } = obj;
+        const privKey = finalKeyData.privKey || oAuthKeyData.privKey;
         this.migratableKey = new BN(privKey, "hex");
       }
 
@@ -78,10 +78,10 @@ class TorusServiceProvider extends ServiceProviderBase {
     if (obj) {
       const localPrivKey = Torus.getPostboxKey(obj);
       this.torusKey = obj;
-      const { finalKeyData, oAuthKeyData } = obj;
-      const privKey = finalKeyData.privKey || oAuthKeyData.privKey;
 
       if (!obj.metadata.upgraded) {
+        const { finalKeyData, oAuthKeyData } = obj;
+        const privKey = finalKeyData.privKey || oAuthKeyData.privKey;
         this.migratableKey = new BN(privKey, "hex");
       }
 
@@ -95,12 +95,12 @@ class TorusServiceProvider extends ServiceProviderBase {
    */
   async triggerHybridAggregateLogin(params: HybridAggregateLoginParams): Promise<TorusHybridAggregateLoginResponse> {
     const obj = await this.customAuthInstance.triggerHybridAggregateLogin(params);
+    this.torusKey = null; // Since there are multiple keys, we don't set the torusKey here.
 
     // `obj` maybe `null` in redirect mode.
     if (obj) {
       const aggregateLoginKey = Torus.getPostboxKey(obj.aggregateLogins[0]);
       const singleLoginKey = Torus.getPostboxKey(obj.singleLogin);
-      this.torusKey = null;
       this.postboxKey = new BN(aggregateLoginKey, "hex");
       this.singleLoginKey = new BN(singleLoginKey, "hex");
     }

--- a/test/setup.mjs
+++ b/test/setup.mjs
@@ -18,14 +18,13 @@ Register({
   rootMode: "upward",
 });
 
-
 const storeFn = {
   getItem(key) {
-    return this[key]
+    return this[key];
   },
   setItem(key, value) {
-    this[key] = value
+    this[key] = value;
   },
-}
-globalThis.localStorage = { ...storeFn }
-globalThis.sessionStorage = { ...storeFn }
+};
+globalThis.localStorage = { ...storeFn };
+globalThis.sessionStorage = { ...storeFn };


### PR DESCRIPTION
Done:
Adds back SFA Service Provider
Adds Torus Key object to Torus Service Provider

This will force anyone moving from SFA/ CustomAuth to tKey to migrate their key into the tKey state.

Todo:
Fix Torus Key object for Torus Service Provider for `triggerHybridAggregateLogin`