### PR TITLE
Fix import tss key for fresh user

### DIFF
--- a/packages/tss/src/tss.ts
+++ b/packages/tss/src/tss.ts
@@ -126,7 +126,7 @@ export class TKeyTSS extends ThresholdKey {
       this._accountSalt = accountSalt;
     }
 
-    if ((this.metadata.tssKeyTypes[this.tssTag] || LEGACY_KEY_TYPE) !== this.tssKeyType) {
+    if (this.metadata.tssPolyCommits[this.tssTag] && (this.metadata.tssKeyTypes[this.tssTag] || LEGACY_KEY_TYPE) !== this.tssKeyType) {
       throw CoreError.default(`tssKeyType mismatch: ${this.metadata.tssKeyTypes[this.tssTag]} !== ${this.tssKeyType}`);
     }
 
@@ -479,7 +479,7 @@ export class TKeyTSS extends ThresholdKey {
    *
    * Reconstructs the TSS private key and exports the ed25519 private key seed.
    */
-  async _UNSAFE_exportTssEd25519Seed(tssOptions: { factorKey: BN; selectedServers: number[]; authSignatures: string[] }): Promise<Buffer> {
+  async _UNSAFE_exportTssEd25519Seed(tssOptions: { factorKey: BN; selectedServers?: number[]; authSignatures: string[] }): Promise<Buffer> {
     const edScalar = await this._UNSAFE_exportTssKey(tssOptions);
 
     // Try to export ed25519 seed. This is only available if import key was being used.


### PR DESCRIPTION
This PR fixes the import TSS key flow for fresh users and adds corresponding tests.

(Background: Previously "import tss key" was only tested for existing users and the code contained a bug where the import tss key flow wouldn't work for a fresh account in combination with ed25519.)