### PR TITLE
triggerLogin: return on redirect

### DIFF
--- a/packages/service-provider-torus/src/TorusServiceProvider.ts
+++ b/packages/service-provider-torus/src/TorusServiceProvider.ts
@@ -9,7 +9,6 @@ import CustomAuth, {
   TorusAggregateLoginResponse,
   TorusHybridAggregateLoginResponse,
   TorusLoginResponse,
-  UX_MODE,
 } from "@toruslabs/customauth";
 import Torus from "@toruslabs/torus.js";
 import BN from "bn.js";
@@ -43,41 +42,49 @@ class TorusServiceProvider extends ServiceProviderBase {
     return this.customAuthInstance.init(params);
   }
 
-  async triggerLogin(params: SubVerifierDetails): Promise<TorusLoginResponse> {
+  /**
+   * Trigger login flow. Returns `null` in redirect mode.
+   */
+  async triggerLogin(params: SubVerifierDetails): Promise<TorusLoginResponse | null> {
     const obj = await this.customAuthInstance.triggerLogin(params);
 
-    if (this.customAuthInstance.config.uxMode === UX_MODE.REDIRECT) {
-      return null;
+    // `obj` maybe `null` in redirect mode.
+    if (obj) {
+      const localPrivKey = Torus.getPostboxKey(obj);
+      this.postboxKey = new BN(localPrivKey, "hex");
     }
 
-    const localPrivKey = Torus.getPostboxKey(obj);
-    this.postboxKey = new BN(localPrivKey, "hex");
     return obj;
   }
 
+  /**
+   * Trigger login flow. Returns `null` in redirect mode.
+   */
   async triggerAggregateLogin(params: AggregateLoginParams): Promise<TorusAggregateLoginResponse> {
     const obj = await this.customAuthInstance.triggerAggregateLogin(params);
 
-    if (this.customAuthInstance.config.uxMode === UX_MODE.REDIRECT) {
-      return null;
+    // `obj` maybe `null` in redirect mode.
+    if (obj) {
+      const localPrivKey = Torus.getPostboxKey(obj);
+      this.postboxKey = new BN(localPrivKey, "hex");
     }
-
-    const localPrivKey = Torus.getPostboxKey(obj);
-    this.postboxKey = new BN(localPrivKey, "hex");
     return obj;
   }
 
+  /**
+   * Trigger login flow. Returns `null` in redirect mode.
+   */
   async triggerHybridAggregateLogin(params: HybridAggregateLoginParams): Promise<TorusHybridAggregateLoginResponse> {
     const obj = await this.customAuthInstance.triggerHybridAggregateLogin(params);
 
-    if (this.customAuthInstance.config.uxMode === UX_MODE.REDIRECT) {
-      return null;
+    // `obj` maybe `null` in redirect mode.
+    if (obj) {
+      const aggregateLoginKey = Torus.getPostboxKey(obj.aggregateLogins[0]);
+      const singleLoginKey = Torus.getPostboxKey(obj.singleLogin);
+      this.postboxKey = new BN(aggregateLoginKey, "hex");
+      this.singleLoginKey = new BN(singleLoginKey, "hex");
     }
 
-    const aggregateLoginKey = Torus.getPostboxKey(obj.aggregateLogins[0]);
-    const singleLoginKey = Torus.getPostboxKey(obj.singleLogin);
-    this.postboxKey = new BN(aggregateLoginKey, "hex");
-    this.singleLoginKey = new BN(singleLoginKey, "hex");
     return obj;
   }
 

--- a/packages/service-provider-torus/src/TorusServiceProvider.ts
+++ b/packages/service-provider-torus/src/TorusServiceProvider.ts
@@ -9,6 +9,7 @@ import CustomAuth, {
   TorusAggregateLoginResponse,
   TorusHybridAggregateLoginResponse,
   TorusLoginResponse,
+  UX_MODE,
 } from "@toruslabs/customauth";
 import Torus from "@toruslabs/torus.js";
 import BN from "bn.js";
@@ -44,6 +45,11 @@ class TorusServiceProvider extends ServiceProviderBase {
 
   async triggerLogin(params: SubVerifierDetails): Promise<TorusLoginResponse> {
     const obj = await this.customAuthInstance.triggerLogin(params);
+
+    if (this.customAuthInstance.config.uxMode === UX_MODE.REDIRECT) {
+      return null;
+    }
+
     const localPrivKey = Torus.getPostboxKey(obj);
     this.postboxKey = new BN(localPrivKey, "hex");
     return obj;
@@ -51,6 +57,11 @@ class TorusServiceProvider extends ServiceProviderBase {
 
   async triggerAggregateLogin(params: AggregateLoginParams): Promise<TorusAggregateLoginResponse> {
     const obj = await this.customAuthInstance.triggerAggregateLogin(params);
+
+    if (this.customAuthInstance.config.uxMode === UX_MODE.REDIRECT) {
+      return null;
+    }
+
     const localPrivKey = Torus.getPostboxKey(obj);
     this.postboxKey = new BN(localPrivKey, "hex");
     return obj;
@@ -58,6 +69,11 @@ class TorusServiceProvider extends ServiceProviderBase {
 
   async triggerHybridAggregateLogin(params: HybridAggregateLoginParams): Promise<TorusHybridAggregateLoginResponse> {
     const obj = await this.customAuthInstance.triggerHybridAggregateLogin(params);
+
+    if (this.customAuthInstance.config.uxMode === UX_MODE.REDIRECT) {
+      return null;
+    }
+
     const aggregateLoginKey = Torus.getPostboxKey(obj.aggregateLogins[0]);
     const singleLoginKey = Torus.getPostboxKey(obj.singleLogin);
     this.postboxKey = new BN(aggregateLoginKey, "hex");


### PR DESCRIPTION
Fixes an error in `triggerLogin` in redirect mode where previously Torus.getPostboxKey fails and briefly shows an error before the redirect occurs.