### PR TITLE
ed25519: Fix export seed != import seed

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -234,7 +234,15 @@ class ThresholdKey implements ITKey {
 
     if (p.delete1OutOf1 && !this.manualSync) throw CoreError.delete1OutOf1OnlyManualSync();
 
-    const { withShare, importKey, neverInitializeNewKey, transitionMetadata, previouslyFetchedCloudMetadata, previousLocalMetadataTransitions } = p;
+    const {
+      withShare,
+      importKey,
+      importEd25519Seed,
+      neverInitializeNewKey,
+      transitionMetadata,
+      previouslyFetchedCloudMetadata,
+      previousLocalMetadataTransitions,
+    } = p;
 
     const previousLocalMetadataTransitionsExists =
       previousLocalMetadataTransitions && previousLocalMetadataTransitions[0].length > 0 && previousLocalMetadataTransitions[1].length > 0;
@@ -272,7 +280,7 @@ class ThresholdKey implements ITKey {
 
         // check for serviceprovider migratableKey for import key from service provider for new user
         // provided no importKey is provided ( importKey take precedent )
-        if (this.serviceProvider.migratableKey && !importKey) {
+        if (this.serviceProvider.migratableKey && !(importKey || importEd25519Seed)) {
           // importkey from server provider need to be atomic, hence manual sync is required.
           const tempStateManualSync = this.manualSync; // temp store manual sync flag
           this.manualSync = true; // Setting this as true since _initializeNewKey has a check where for importkey from server provider need to be atomic, hence manual sync is required.
@@ -285,7 +293,7 @@ class ThresholdKey implements ITKey {
             initializeModules: true,
             importedKey: importKey,
             delete1OutOf1: p.delete1OutOf1,
-            importEd25519Seed: params?.importEd25519Seed,
+            importEd25519Seed,
           });
         }
 

--- a/packages/default/test/shared.js
+++ b/packages/default/test/shared.js
@@ -66,6 +66,7 @@ function compareReconstructedKeys(a, b, message) {
 export const sharedTestCases = (mode, torusSP, storageLayer) => {
   const customSP = torusSP;
   const customSL = storageLayer;
+
   describe("tkey", function () {
     let tb;
 
@@ -1402,6 +1403,7 @@ export const sharedTestCases = (mode, torusSP, storageLayer) => {
       }
     });
   });
+
   describe("tkey error cases", function () {
     let tb;
     let resp1;


### PR DESCRIPTION
Fixes #285 

When `serviceProvider.migratableKey` was set, `importKey` was not set, and `importEd25519Seed` was set, it would run `serviceProvider.migratableKey` without `importEd25519Seed`. Now, it runs the else case with `importEd25519Seed` instead.

Question:
Or should we import `migratableKey` + `importEd25519Seed` in this case? @himanshuchawla009 @ieow 