### PR TITLE
fix: allow tss commits to be read when key not reconstructed.

### DIFF
--- a/packages/tss/src/tss.ts
+++ b/packages/tss/src/tss.ts
@@ -238,7 +238,6 @@ export class TKeyTSS extends ThresholdKey {
    * shares, as stored in Metadata.
    */
   getTSSCommits(): Point[] {
-    if (!this.privKey) throw CoreError.default("tss pub cannot be returned until you've reconstructed tkey");
     if (!this.metadata) throw CoreError.metadataUndefined();
     const tssPolyCommits = this.metadata.tssPolyCommits[this.tssTag];
     if (!tssPolyCommits) throw CoreError.default(`tss poly commits not found for tssTag ${this.tssTag}`);


### PR DESCRIPTION
This is needed to be able to retrieve the TSS public key where the key is not reconstructed since it calls getTssCommits().